### PR TITLE
Add blocklist functionality

### DIFF
--- a/.traefik.yml
+++ b/.traefik.yml
@@ -1,7 +1,7 @@
 displayName: geoblock
 type: middleware
 import: github.com/nscuro/traefik-plugin-geoblock
-summary: traefik plugin to whitelist requests based on geolocation
+summary: traefik plugin to block or allow requests based on geolocation
 testData:
   # It doesn't appear to be possible to get the pilot plugin analyzer
   # to load local files. To prevent errors, the plugin is disabled here.
@@ -9,6 +9,9 @@ testData:
   enabled: false
   # databaseFilePath: IP2LOCATION-LITE-DB1.IPV6.BIN
   # allowedCountries: [ "CH", "DE" ]
+  # blockedCountries: [ "RU" ]
+  # defaultAllow: false
   # allowPrivate: true
   # disallowedStatusCode: 403
   # allowedIPBlocks: ["66.249.64.0/19"]
+  # blockedIPBlocks: ["66.249.64.0/24"]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Latest GitHub release](https://img.shields.io/github/v/release/nscuro/traefik-plugin-geoblock?sort=semver)](https://github.com/nscuro/traefik-plugin-geoblock/releases/latest)
 [![License](https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg)](LICENSE)  
 
-*traefik-plugin-geoblock is a traefik plugin to whitelist requests based on geolocation*
+*traefik-plugin-geoblock is a traefik plugin to allow or block requests based on geolocation*
 
 > This projects includes IP2Location LITE data available from [`lite.ip2location.com`](https://lite.ip2location.com/database/ip-country).
 
@@ -49,10 +49,16 @@ http:
           databaseFilePath: /plugins-local/src/github.com/nscuro/traefik-plugin-geoblock/IP2LOCATION-LITE-DB1.IPV6.BIN
           # Whitelist of countries to allow (ISO 3166-1 alpha-2)
           allowedCountries: [ "AT", "CH", "DE" ]
+          # Blocklist of countries to block (ISO 3166-1 alpha-2)
+          blockedCountries: [ "RU" ]
+          # Default allow indicates that if an IP is in neither block list nor allow lists, it should be allowed.
+          defaultAllow: false
           # Allow requests from private / internal networks?
           allowPrivate: true
           # HTTP status code to return for disallowed requests (default: 403)
           disallowedStatusCode: 204
           # Add CIDR to be whitelisted, even if in a non-allowed country
           allowedIPBlocks: ["66.249.64.0/19"]
+          # Add CIDR to be blacklisted, even if in an allowed country or IP block
+          blockedIPBlocks: ["66.249.64.5/32"]
 ```


### PR DESCRIPTION
This adds blocklist functionality, while preserving the allowlist. To make this more useful, we also introduce a default policy:  if an IP matches neither allow- or block-list, it will be allowed or not based on the default policy.

For CIDR-based lists, higher specificity CIDRs should always take priority to lower-specificity ones.  In the event of a tie, the block list should always take priority over the allow list.

Fixes #20 