### PR TITLE
Fixes for sparse configs

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -169,10 +169,6 @@ func (p Plugin) CheckAllowed(ip string) (allow bool, country string, err error) 
 		return false, ip, fmt.Errorf("lookup of %s failed: %w", ip, err)
 	}
 
-	if country == "-" {
-		return p.allowPrivate, country, nil
-	}
-
 	if country != "-" {
 		for _, item := range p.blockedCountries {
 			if item == country {

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -106,8 +106,8 @@ func TestPlugin_ServeHTTP(t *testing.T) {
 			Enabled:              true,
 			DatabaseFilePath:     dbFilePath,
 			AllowedCountries:     []string{},
-			AllowPrivate:         true,
 			DisallowedStatusCode: http.StatusOK,
+			DefaultAllow:         true,
 		}
 
 		plugin, err := New(context.TODO(), &noopHandler{}, cfg, pluginName)
@@ -157,6 +157,7 @@ func TestPlugin_ServeHTTP(t *testing.T) {
 			AllowedCountries:     []string{},
 			AllowPrivate:         false,
 			DisallowedStatusCode: http.StatusForbidden,
+			DefaultAllow:         false,
 		}
 
 		plugin, err := New(context.TODO(), &noopHandler{}, cfg, pluginName)


### PR DESCRIPTION
I had a couple fixes for some configuration edge cases which I somehow failed to get included in the previous PR.

- allow unknown country IPs to continue being processed
- fix default allows for the privateIP functionality to work