### PR TITLE
Enable DNS Resolution

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -263,20 +263,41 @@ func (p Plugin) Lookup(ip string) (string, error) {
 	return record.Country_short, nil
 }
 
-// Create IP Networks using CIDR block array
+// Create IP Networks using CIDR block array or try to resolve via DNS Lookup
 func initIPBlocks(ipBlocks []string) ([]*net.IPNet, error) {
+    var ipBlocksNet []*net.IPNet
 
-	var ipBlocksNet []*net.IPNet
+    for _, item := range ipBlocks {
+        // Try to parse as CIDR first
+        _, block, err := net.ParseCIDR(item)
+        if err == nil {
+            ipBlocksNet = append(ipBlocksNet, block)
+            continue
+        }
 
-	for _, cidr := range ipBlocks {
-		_, block, err := net.ParseCIDR(cidr)
-		if err != nil {
-			return nil, fmt.Errorf("parse error on %q: %v", cidr, err)
-		}
-		ipBlocksNet = append(ipBlocksNet, block)
-	}
+        // If CIDR parsing fails, try DNS resolution
+        ips, err := net.LookupIP(item)
+        if err != nil {
+            return nil, fmt.Errorf("failed to parse CIDR or resolve DNS for %q: %v", item, err)
+        }
 
-	return ipBlocksNet, nil
+        // Convert resolved IPs to /32 (IPv4) or /128 (IPv6) networks
+        for _, ip := range ips {
+            var cidr string
+            if ip.To4() != nil {
+                cidr = ip.String() + "/32"
+            } else {
+                cidr = ip.String() + "/128"
+            }
+            _, block, err := net.ParseCIDR(cidr)
+            if err != nil {
+                return nil, fmt.Errorf("failed to create CIDR for resolved IP %s: %v", ip, err)
+            }
+            ipBlocksNet = append(ipBlocksNet, block)
+        }
+    }
+
+    return ipBlocksNet, nil
 }
 
 // isAllowedIPBlocks checks if an IP is allowed base on the allowed CIDR blocks


### PR DESCRIPTION
This pull request enhances the `initIPBlocks` function in `plugin.go` to support both CIDR block parsing and DNS resolution for input strings. This change increases the flexibility of the function by allowing it to handle domain names in addition to CIDR blocks.

### Enhancements to `initIPBlocks` function:

* The function now attempts to parse each input string as a CIDR block first. If parsing fails, it falls back to resolving the string as a domain name via DNS.
* For resolved domain names, the function converts the resulting IP addresses into `/32` (for IPv4) or `/128` (for IPv6) CIDR networks before adding them to the list of IP networks.
* Improved error handling ensures that meaningful error messages are returned when neither CIDR parsing nor DNS resolution succeeds.